### PR TITLE
Update to use upstream CockroachDB gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ group :development do
   # gem "spring"
 end
 
-gem "activerecord-cockroachdb-adapter", "~> 7.0.0", :git => "https://github.com/conradwt/activerecord-cockroachdb-adapter", :branch => "upgrade-to-support-rails-7.0.0"
+gem "activerecord-cockroachdb-adapter",
+  :git => "https://github.com/cockroachdb/activerecord-cockroachdb-adapter",
+  :branch => "master"
 
 gem "sassc-rails", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
-  remote: https://github.com/conradwt/activerecord-cockroachdb-adapter
-  revision: a34428ba3e60e54bbf699fc560856d11e487a681
-  branch: upgrade-to-support-rails-7.0.0
+  remote: https://github.com/cockroachdb/activerecord-cockroachdb-adapter
+  revision: 2292dd5bd03f52dff4b6565b86c63e94cc9b397f
+  branch: master
   specs:
     activerecord-cockroachdb-adapter (7.0.0)
-      activerecord (~> 7.0.1)
-      pg (~> 1.2.3)
-      rgeo-activerecord (~> 7.0.1)
+      activerecord (~> 7.0.3)
+      pg (~> 1.2)
+      rgeo-activerecord (~> 7.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -106,7 +106,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    minitest (5.15.0)
+    minitest (5.16.1)
     msgpack (1.5.2)
     net-imap (0.2.3)
       digest
@@ -127,13 +127,13 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
-    pg (1.2.3)
+    pg (1.4.1)
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3.1)
-    rack-test (1.1.0)
-      rack (>= 1.0, < 3)
+    rack-test (2.0.0)
+      rack (>= 1.3)
     rails (7.0.3)
       actioncable (= 7.0.3)
       actionmailbox (= 7.0.3)
@@ -151,7 +151,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.2)
+    rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     railties (7.0.3)
       actionpack (= 7.0.3)
@@ -175,7 +175,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sprockets (4.0.3)
+    sprockets (4.1.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)
@@ -196,14 +196,14 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   arm64-darwin-21
   x86_64-darwin-20
 
 DEPENDENCIES
-  activerecord-cockroachdb-adapter (~> 7.0.0)!
+  activerecord-cockroachdb-adapter!
   bootsnap
   debug
   jbuilder

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Note: This tutorial was created using macOS 12.4.
     ```zsh
     bundle remove pg
     bundle add activerecord-cockroachdb-adapter \
-      --git "https://github.com/conradwt/activerecord-cockroachdb-adapter" \
-      --branch "upgrade-to-support-rails-7.0.0"
+      --git "https://github.com/cockroachdb/activerecord-cockroachdb-adapter" \
+      --branch "master"
     bundle add sassc-rails
     ```
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_13_051015) do
-
+ActiveRecord::Schema[7.0].define(version: 2021_05_13_051015) do
   create_table "posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "title"
     t.text "body"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
 end


### PR DESCRIPTION
This PR supports the following features:

- upgrade to use upstream Cockroach gem